### PR TITLE
Allow for searching by the full project name

### DIFF
--- a/STP.py
+++ b/STP.py
@@ -14,7 +14,7 @@ class SourceTree:
     return [m.group(0) for m in matches]
 
   def _splitMatchWords(self, title):
-    res = []
+    res = [title]
     cam = self._camel_case_split(title)
     for m in cam:
       ret = re.split('-|_| |',m)


### PR DESCRIPTION
Currently if a project has a dash in its name, searching by the full name is not possible - it gives empty result list.
This PR aims to fix this.

### Before:

![image](https://user-images.githubusercontent.com/13980973/185130827-9e63b368-3342-4205-8d49-135b407e449c.png)
![image](https://user-images.githubusercontent.com/13980973/185130935-d65e66dd-2f3a-4f10-a7f3-560fe6693829.png)

### After:

![image](https://user-images.githubusercontent.com/13980973/185131084-397c7678-39ec-48c2-a6cd-c9abb611032e.png)
